### PR TITLE
Dockerize the Project[WIP]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+
+FROM ruby:2.7.6
+
+WORKDIR /app 
+# /usr/src/app
+
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt update
+RUN apt install libpq-dev -y
+RUN apt install libjemalloc-dev -y
+RUN apt install libvips42 -y
+RUN apt install yarn -y
+COPY Gemfile Gemfile.lock ./
+COPY . .
+RUN ["bin/setup"]
+RUN ["bin/rails houdini:nonprofit:create"]
+
+CMD [ "bin/rails", "server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+
+services:
+
+  postgres:
+    image: postgres
+    volumes:
+      - ./postgresdata:/var/lib/postgresql/data
+
+    environment:
+      - POSTGRES_USER=houdini_user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=houdini_db
+    ports:
+        - '5432:5432'
+    command: -p 5432
+    restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready" ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
+    
+  ruby:
+    image: ruby:2.7.6
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    restart: on-failure
+    environment:
+      - RUBY_VERSION=2.7
+      - RAILS_ENV=production
+      - DATABASE_HOST=localhost
+      - POSTGRES_USER=houdini_user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=houdini_db
+    ports:
+      - "5000:5000"
+    depends_on:
+      - postgres
+


### PR DESCRIPTION
The Houdini project is not much friendlier with new contributors because is very difficult and have many steps for configure all project and for other operational systems is not documentation install steps, one of many other solutions for this problem is creating a docker for the software.

This PR still in developer phase, not yet is  full functions.